### PR TITLE
fixed cart page error and added empty cart message

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -2,6 +2,14 @@ import { getLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
   const cartItems = getLocalStorage("so-cart");
+  //fix cart error and add a message if cart is empty
+  if (!cartItems || cartItems.length === 0) {
+    document.querySelector(".product-list").innerHTML =
+      "<p>Your cart is empty.</p>";
+    return;
+  }
+
+  //map over cart items and create html for each item
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
   document.querySelector(".product-list").innerHTML = htmlItems.join("");
 }


### PR DESCRIPTION
When there are no items in the cart, the cart.html page shows a ;Your cart is empty' message. 

If you want to see this in action, clear localStorage in devtools